### PR TITLE
Egyértelmű form és hibaüzenet

### DIFF
--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -7,7 +7,7 @@ hu:
       models:
         order:
           must_have_sch_logo: A plakáton rajta kell lennie a Schönherz logónak
-          must_be_right_format: Az igénylésnek png/jpg formátumúnak kell lennie
+          must_be_right_format: Az igénylésnek png/jpg/pdf formátumúnak kell lennie
           attributes:
             group:
               required: megadása kötelező

--- a/config/locales/translation_hu.yml
+++ b/config/locales/translation_hu.yml
@@ -93,7 +93,7 @@ hu:
         group: Kör
         group_id: Kör
         has_sch_logo: Igénylésen van Schönherz logó
-        has_right_format: Igénylés png/jpg formátumú
+        has_right_format: Igénylés png/jpg/pdf formátumú
         has_date: Az igénylésemen szerepel lejárati időpont, vagy a rendezvény dátuma
         accepted_terms_of_service: Elolvastam a plakátolási szabályzatot
         paper_size_enum:


### PR DESCRIPTION
A weboldal három formátumot fogad el, viszont a hibaüzenet és a formátum pipáló az csak png/jpg típusra van értelmezve. Hozzáírtam a pdf filekiterjesztést is, az egységesítés miatt.