### PR TITLE
Értesítés string-ek frissítése egyszerűbb rendelés típús megkülönböztetéséhez

### DIFF
--- a/app/helpers/orders_helper.rb
+++ b/app/helpers/orders_helper.rb
@@ -2,10 +2,10 @@ module OrdersHelper
     def send_notification(order)
         if Rails.env.production?
             uri = URI('https://ntfy.noeyouth.eu/kbpr')
-            body = "#{Group.find_by(id: order["group_id"]).name} rendelt plakátot. #{if order["printed_by_me"] == "1" then "Ők nyomtatják" else "Kbpr nyomtatja" end}"
+            body = "#{Group.find_by(id: order["group_id"]).name} #{if order["printed_by_me"] == "1" then "nyomtat" else "rendelt" end} plakátot."
             headers = { 'Authorization' => 'Bearer ' + Rails.application.credentials.notification_api_key,
-                    'Title' => "Új rendelés",
-                    'Tags' => 'inbox_tray, uj-rendeles',
+                    'Title' => "#{if order["printed_by_me"] == "1" then "Egy kör nyomtat" else "Új rendelés" end}",
+                    'Tags' => '#{if order["printed_by_me"] == "1" then "printer, uj-nyomtatas" else "inbox_tray, uj-rendeles" end}',
                     'Priority' =>  'default',
                     'Action' => 'view, Megnyitás, https://kbpr.sch.bme.hu/orders, clear=true'}
             response = Net::HTTP.post(uri, body.to_json, headers)

--- a/app/helpers/orders_helper.rb
+++ b/app/helpers/orders_helper.rb
@@ -5,7 +5,7 @@ module OrdersHelper
             body = "#{Group.find_by(id: order["group_id"]).name} #{if order["printed_by_me"] == "1" then "nyomtat" else "rendelt" end} plakátot."
             headers = { 'Authorization' => 'Bearer ' + Rails.application.credentials.notification_api_key,
                     'Title' => "#{if order["printed_by_me"] == "1" then "Egy kör nyomtat" else "Új rendelés" end}",
-                    'Tags' => '#{if order["printed_by_me"] == "1" then "printer, uj-nyomtatas" else "inbox_tray, uj-rendeles" end}',
+                    'Tags' => "#{if order["printed_by_me"] == "1" then "printer, uj-nyomtatas" else "inbox_tray, uj-rendeles" end}",
                     'Priority' =>  'default',
                     'Action' => 'view, Megnyitás, https://kbpr.sch.bme.hu/orders, clear=true'}
             response = Net::HTTP.post(uri, body.to_json, headers)


### PR DESCRIPTION
Én nyomtatom bepipálása esetén könnyebben megkülönböztethető értesítések:
Végén Kbpr/Kör nyomtatja -> redelt/nyomtat kulcsszó használata
Új rendelés cím -> Egy kör nyomtat / Új rendelés
Emoji: 🖨 ha én nyomtatom, 📥 ha rendelem
Tag: `uj-rendeles` és `uj-nyomtatas` tagekre szétszedve