### PR TITLE
Order filter expand

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -4,9 +4,20 @@ class OrdersController < ApplicationController
   # skip_before_action :basic_authorization, only: [:finalize, :update]
   # GET /orders or /orders.json
   def index
-    search_attributes = {state: params.dig(:order, :state)|| :processing}
+    search_attributes = {state: params.dig(:order, :state)|| :processing,}
     @search_order = Order.new(search_attributes)
-    @orders = Order.where(search_attributes).order(finalized_at: :desc).page(params[:page])
+    @orders = Order.joins(order_items: :item)
+                   .where(search_attributes)
+
+    if params[:item_id].present?
+      @orders = @orders.where(order_items: { item_id: params.dig(:order, :item_id) })
+    end
+
+    if params[:completed_by_id].present?
+      @orders = @orders.where(completed_by_id: { completed_by_id: params.dig(:order, :completed_by_id) })
+    end
+
+    @orders = @orders.order(finalized_at: :desc).page(params[:page])
   end
 
   def my_orders

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -4,17 +4,21 @@ class OrdersController < ApplicationController
   # skip_before_action :basic_authorization, only: [:finalize, :update]
   # GET /orders or /orders.json
   def index
-    search_attributes = {state: params.dig(:order, :state)|| :processing,}
+    search_attributes = {state: params.dig(:order, :state)|| :processing}
     @search_order = Order.new(search_attributes)
     @orders = Order.joins(order_items: :item)
                    .where(search_attributes)
 
-    if params[:item_id].present?
-      @orders = @orders.where(order_items: { item_id: params.dig(:order, :item_id) })
+    if params.dig(:order, :item_id).present?
+      @orders = @orders.where(order_items: {item_id: params.dig(:order, :item_id)} )
     end
 
-    if params[:completed_by_id].present?
-      @orders = @orders.where(completed_by_id: { completed_by_id: params.dig(:order, :completed_by_id) })
+    if params.dig(:order, :completed_by_id).present?
+      @orders = @orders.where(completed_by_id: params.dig(:order, :completed_by_id) )
+    end
+
+    if params.dig(:order, :group_id).present?
+      @orders = @orders.where(group_id: params.dig(:order, :group_id) )
     end
 
     @orders = @orders.order(finalized_at: :desc).page(params[:page])

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -7,8 +7,30 @@
 
       <div class="my-5">
         <%= form.label :state, class: 'text-xl' %>
-        <%= form.select :state, Order.states.values.map { |status| [Order.human_enum_name(:states, status), status] }, { prompt: "-- Válaszd ki a köröd! --" }, class: "text-bg-dark block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
+        <%= form.select :state, Order.states.values.map { |status| [Order.human_enum_name(:states, status), status] },
+          { prompt: "-- Válaszd ki a köröd! --" },
+          class: "text-bg-dark block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full"%>
       </div>
+      
+      <div class="my-5">
+        <%= form.label :completed_by_id, 'Elkészítette', class: 'text-xl' %>
+        <%= form.checkbox  :completed_by_id %>
+        <%= form.select :completed_by_id, User.order(:name).map { |user| [user.name, user.id] },
+          { prompt: "-- Válaszd ki a felhasználót! --" },
+          class: "text-bg-dark block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full",
+          disabled: !params[:completed_by_id].present? %>
+        <% if !params[:completed_by_id].present? %>
+          <%= hidden_field_tag 'order[completed_by_id]', '' %>
+        <% end %>
+      </div>
+
+      <div class="my-5">
+        <%= form.label :item_id, 'Termék típus', class: 'text-xl' %>
+        <%= form.select :item_id, Item.order(:name).map { |item| [item.name, item.id] },
+          { prompt: "-- Válaszd ki a termék típusát! --" },
+          class: "text-bg-dark block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full"%>
+      </div>
+
       <%= form.submit 'Szűrés', class: 'btn px-16 text-xl' %>
     <% end %>
   </div>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -5,29 +5,32 @@
     <%= form_with(model: @search_order, url: orders_path, method: :get, class: "contents",
                   data: { turbo: false }, builder: CustomFormBuilder) do |form| %>
 
-      <div class="my-5">
+      <div class="my-5 flex items-center space-x-4">
         <%= form.label :state, class: 'text-xl' %>
         <%= form.select :state, Order.states.values.map { |status| [Order.human_enum_name(:states, status), status] },
-          { prompt: "-- Válaszd ki a köröd! --" },
+          { prompt: "-- Válaszd ki a rendelés állapotát! --" },
           class: "text-bg-dark block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full"%>
       </div>
       
-      <div class="my-5">
-        <%= form.label :completed_by_id, 'Elkészítette', class: 'text-xl' %>
-        <%= form.checkbox  :completed_by_id %>
+      <div class="my-5 flex items-center space-x-4">
+        <%= form.label :completed_by_id, 'Elkészítette', class: "text-xl" %>
         <%= form.select :completed_by_id, User.order(:name).map { |user| [user.name, user.id] },
           { prompt: "-- Válaszd ki a felhasználót! --" },
-          class: "text-bg-dark block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full",
-          disabled: !params[:completed_by_id].present? %>
-        <% if !params[:completed_by_id].present? %>
-          <%= hidden_field_tag 'order[completed_by_id]', '' %>
-        <% end %>
+          class: "text-bg-dark block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full"
+          %>
       </div>
 
-      <div class="my-5">
-        <%= form.label :item_id, 'Termék típus', class: 'text-xl' %>
+      <div class="my-5 flex items-center space-x-4">
+        <%= form.label :item_id, 'Terméktípus', class: "text-xl" %>
         <%= form.select :item_id, Item.order(:name).map { |item| [item.name, item.id] },
           { prompt: "-- Válaszd ki a termék típusát! --" },
+          class: "text-bg-dark block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full"%>
+      </div>
+
+      <div class="my-5 flex items-center space-x-4">
+        <%= form.label :group_id, 'Rendelő kör', class: "text-xl whitespace-nowrap" %>
+        <%= form.select :group_id, Group.order(:name).map { |group| [group.name, group.id] },
+          { prompt: "-- Válaszd ki a kört! --" },
           class: "text-bg-dark block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full"%>
       </div>
 


### PR DESCRIPTION
Ígérem az utolsó PR az évben😅

## Szűrő bővítése a /orders útvonalon
Az alapvető működéshez nem nyúltam, az állapot szűrőt kötelező megadni, (ahogy eddig is), hogy legyen mi alapján szűrni.
Ezt bővítettem ki további opcionális szűrőkkel, ahol a default értékek üresek.

Opcionális szűrők, amiket implementáltam:
- ki készítette
- van-e a rendelésben adott termék
- melyik kör adta le a rendelést

![image](https://github.com/user-attachments/assets/31aea41f-2244-4b3d-8daf-a79a28ca8eb3)
